### PR TITLE
Update helios demo with send/handshake options

### DIFF
--- a/apps/helios-demo/src/App.tsx
+++ b/apps/helios-demo/src/App.tsx
@@ -7,13 +7,15 @@ declare global {
     }
 }
 import nacl from "tweetnacl";
-import { Contract, BrowserProvider, JsonRpcSigner, toUtf8Bytes } from "ethers";
-import { sendEncryptedMessage } from "@verbeth/sdk";
+import { Contract, BrowserProvider, JsonRpcSigner } from "ethers";
+import { sendEncryptedMessage, initiateHandshake } from "@verbeth/sdk";
 import { useHelios } from "./helios.js";
 import type { LogChainV1 } from "@verbeth/contracts/typechain-types";
-// ABI minimale con solo sendMessage
+// ABI minimale necessario per l'invio di messaggi e handshake
 const ABI = [
-    "function sendMessage(bytes ciphertext, bytes32 topic, uint256 timestamp, uint256 nonce)"
+    "function sendMessage(bytes ciphertext, bytes32 topic, uint256 timestamp, uint256 nonce)",
+    "function initiateHandshake(bytes32 recipientHash, bytes identityPubKey, bytes ephemeralPubKey, bytes plaintextPayload)",
+    "function respondToHandshake(bytes32 inResponseTo, bytes ciphertext)"
 ];
 const LOGCHAIN_ADDR = "0xf9fe7E57459CC6c42791670FaD55c1F548AE51E8"; 
 
@@ -24,6 +26,9 @@ export default function App() {
     const [address, setAddress] = useState<string>("");
     const [ready, setReady] = useState(false);
     const [msg, setMsg] = useState("");
+    const [mode, setMode] = useState<"send" | "handshake">("send");
+    const [recipientPubKeyHex, setRecipientPubKeyHex] = useState("0x");
+    const [handshakeAddress, setHandshakeAddress] = useState("");
     const logRef = useRef<HTMLTextAreaElement | null>(null);
 
     // chiavi dimostrative 
@@ -51,31 +56,34 @@ export default function App() {
     async function handleSend() {
         if (!readProvider || !signer) return;
 
-        // // 1. costruisci la tx offline
-        // const contractForPop = new Contract(LOGCHAIN_ADDR, ABI, signer);
-        // const txReq = await contractForPop.populateTransaction.sendMessage(/* … */);
-
-        // // 2. firma con il wallet
-        // const rawTx = await signer.signTransaction(txReq); // deve essere supportato!
-
-        // // 3. trasmetti via Helios (readProvider)
-        // const txResp = await readProvider.broadcastTransaction(rawTx);
-        // await txResp.wait();
-
-        // senno faccio passare la tx dal RPC di MetaMask
         const contract = new Contract(LOGCHAIN_ADDR, ABI, signer) as unknown as LogChainV1;
 
-        await sendEncryptedMessage({
-            contract,
-            topic: "0x" + "00".repeat(32),         
-            message: msg,
-            recipientPubKey: recipient.publicKey,
-            senderAddress: await signer.getAddress(),
-            senderSignKeyPair: senderSign,
-            timestamp: Math.floor(Date.now() / 1000)
-        });
+        if (mode === "send") {
+            const cleanHex = recipientPubKeyHex.trim().replace(/^0x/, "");
+            const pubKey = Buffer.from(cleanHex, "hex");
+            await sendEncryptedMessage({
+                contract,
+                topic: "0x" + "00".repeat(32),
+                message: msg,
+                recipientPubKey: pubKey,
+                senderAddress: await signer.getAddress(),
+                senderSignKeyPair: senderSign,
+                timestamp: Math.floor(Date.now() / 1000)
+            });
+            logRef.current!.value += `✓ sent: ${msg}\n`;
+        } else {
+            const identity = nacl.box.keyPair();
+            const ephemeral = nacl.box.keyPair();
+            await initiateHandshake({
+                contract,
+                recipientAddress: handshakeAddress.trim(),
+                identityPubKey: identity.publicKey,
+                ephemeralPubKey: ephemeral.publicKey,
+                plaintextPayload: msg
+            });
+            logRef.current!.value += `✓ handshake: ${msg}\n`;
+        }
 
-        logRef.current!.value += `✓ sent: ${msg}\n`;
         setMsg("");
     }
 
@@ -101,6 +109,31 @@ export default function App() {
                 readOnly
             />
 
+            <select
+                className="w-full max-w-xl p-2 border rounded"
+                value={mode}
+                onChange={(e) => setMode(e.target.value as "send" | "handshake")}
+            >
+                <option value="send">Invia messaggio cifrato</option>
+                <option value="handshake">Inizia handshake</option>
+            </select>
+
+            {mode === "send" ? (
+                <input
+                    className="w-full max-w-xl p-2 border rounded"
+                    placeholder="recipient pubkey (hex)"
+                    value={recipientPubKeyHex}
+                    onChange={(e) => setRecipientPubKeyHex(e.target.value)}
+                />
+            ) : (
+                <input
+                    className="w-full max-w-xl p-2 border rounded"
+                    placeholder="recipient address"
+                    value={handshakeAddress}
+                    onChange={(e) => setHandshakeAddress(e.target.value)}
+                />
+            )}
+
             <input
                 className="w-full max-w-xl p-2 border rounded"
                 placeholder="scrivi un messaggio"
@@ -110,10 +143,16 @@ export default function App() {
 
             <button
                 onClick={handleSend}
-                disabled={!ready || !msg}
+                disabled={
+                    !ready ||
+                    !msg ||
+                    (mode === "send"
+                        ? recipientPubKeyHex.trim().length !== 66
+                        : handshakeAddress.trim() === "")
+                }
                 className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
             >
-                {ready ? "Invia cifrato" : "Sync…"}
+                {mode === "send" ? (ready ? "Invia cifrato" : "Sync…") : (ready ? "Handshake" : "Sync…")}
             </button>
         </div>
     );


### PR DESCRIPTION
## Summary
- extend the demo to allow sending encrypted messages to a user-supplied public key
- add ability to initiate a handshake to an address entered by the user
- validate pubkey/address inputs and provide ABI for handshake functions

## Testing
- `pnpm -r test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_685012a1202c832888153be43a2db39a